### PR TITLE
Fix link to tutorial

### DIFF
--- a/lectures/acse/020_tutorial_jboss_project.md
+++ b/lectures/acse/020_tutorial_jboss_project.md
@@ -10,7 +10,7 @@ title: Creating Java EE projects with JBoss Tools
 1. [Creating an Enterprise Application from scratch](#create)
 
 ##<a id="precond" name="precond" />Preconditions##
-* Make sure **WildFly** and **Eclipse with JBoss Tools Plug-in** are properly **installed** and configured ([tutorial](010_tutorial_jboss_setup.html)).
+* Make sure **WildFly** and **Eclipse with JBoss Tools Plug-in** are properly **installed** and configured ([tutorial](010_setting_up_the_dev_environment)).
 * **Start Eclipse with JBoss Tools Plug-in** and make sure the **Java EE perspective** is **opened**.
 * Make sure that a **WildFly 8 Runtime Server** is configured in Eclipse as outlined in the [first tutorial](010_setting_up_the_dev_environment).
 


### PR DESCRIPTION
The link referenced the setup page from EAI, which has been integrated into the 010_setting_up_the_dev_environment tutorial page.
