### PR TITLE
Fix mixed content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # used to address resources (stylesheets, javascript)
-url: http://wwu-pi.github.io/tutorials
+url: https://wwu-pi.github.io/tutorials
 
 # lectures to be included when generating overview
 # - use the directory name within the lectures directory


### PR DESCRIPTION
Subresources should be included over HTTPS; otherwise modern browsers won't load them.

![](https://maximilianhils.com/upload/2015-05/2015-05-05_11-46-24.png)
